### PR TITLE
Take hound dashboard out of the table

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,23 +26,20 @@ a.Error { background-color: #f60;}
 
     <div class="container">
 
-<h1>Hound</h1>
+        <h1>Hound</h1>
+
+    <div>
+        <div>
+            {{ range $index, $element := .Alerts }}
+            <a class="box {{$element.Status}}" href="#alert-{{$element.Hash}}"></a>
+            {{ end }}
+            <br style="clear: both" />
+        </div>
+        <img width="800" height="150" src="{{.GraphiteBase}}?width=800&height=150&_salt=1399312175.381&target=keepLastValue({{.MetricBase}}errors)&target=keepLastValue({{.MetricBase}}successes)&target=keepLastValue({{.MetricBase}}failures)&from=-24hours&areaMode=stacked&bgcolor=ffffff&fgcolor=333333&colorList=ff6600,44bb44,ff0000"/><br />
+        <img width="800" height="75" src="{{.GraphiteBase}}?width=800&height=75&hideGrid=true&hideLegend=true&graphOnly=true&hideAxes=true&_salt=1399312175.381&target=keepLastValue({{.MetricBase}}errors)&target=keepLastValue({{.MetricBase}}successes)&target=keepLastValue({{.MetricBase}}failures)&from=-7days&areaMode=stacked&bgcolor=eeeeee&fgcolor=333333&colorList=ff6600,44bb44,ff0000"/>
+    </div>
 
 <table class="table table-condensed table-striped">
-
-    <tr>
-        <td colspan="4">
-            <div>
-                {{ range $index, $element := .Alerts }}
-                <a class="box {{$element.Status}}" href="#alert-{{$element.Hash}}"></a>
-                {{ end }}
-                <br style="clear: both" />
-            </div>
-            <img width="800" height="150" src="{{.GraphiteBase}}?width=800&height=150&_salt=1399312175.381&target=keepLastValue({{.MetricBase}}errors)&target=keepLastValue({{.MetricBase}}successes)&target=keepLastValue({{.MetricBase}}failures)&from=-24hours&areaMode=stacked&bgcolor=ffffff&fgcolor=333333&colorList=ff6600,44bb44,ff0000"/><br />
-            <img width="800" height="75" src="{{.GraphiteBase}}?width=800&height=75&hideGrid=true&hideLegend=true&graphOnly=true&hideAxes=true&_salt=1399312175.381&target=keepLastValue({{.MetricBase}}errors)&target=keepLastValue({{.MetricBase}}successes)&target=keepLastValue({{.MetricBase}}failures)&from=-7days&areaMode=stacked&bgcolor=eeeeee&fgcolor=333333&colorList=ff6600,44bb44,ff0000"/>
-        </td>
-    </tr>
-
 <tr>
 <th>Metric</th>
 <th></th>


### PR DESCRIPTION
The dashboard view isn't really a part of the table, so I'm taking it
out in order to simplify future work here.