### PR TITLE
:arrow_up: go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.8
+go: "1.10"
 
 before_install:
   - go get golang.org/x/tools/cmd/cover

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.10
 WORKDIR /go/src/app
 COPY . .
 RUN go-wrapper install


### PR DESCRIPTION
go is version 1.10 in ubuntu 18.04. Of course this doesn't matter *that*
much since hound is run in docker, but let's keep it up to date anyways.