### PR TITLE
Remove go-wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 FROM golang:1.10
 WORKDIR /go/src/app
 COPY . .
-RUN go-wrapper install
 
 ENV HOUND_HTTP_PORT=9998
 ENV HOUND_TEMPLATE_FILE=/go/src/app/index.html
 ENV HOUND_SMTP_SERVER=postfix
 ENV HOUND_SMTP_PORT=25
 EXPOSE 9998
-CMD ["go-wrapper", "run", "-config", "/config.json"]
+CMD ["go", "run", "-config", "/config.json"]
 


### PR DESCRIPTION
This isn't around in the go 1.10 docker container. See:
https://github.com/docker-library/golang/pull/205