### PR TITLE
Update build command with static linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ROOT_DIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 all: hound
 
 hound: hound.go smtp.go alert.go alertscollection.go config.go
-	go build .
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .
 
 fmt:
 	go fmt *.go


### PR DESCRIPTION
Making the binary more portable, and less likely for problems wherever
we run it.

From: http://blog.wrouesnel.com/articles/Totally%20static%20Go%20builds/