### PR TITLE
Close the http.Get() request after opened

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -96,7 +96,8 @@ type fetcher interface {
 type httpFetcher struct{}
 
 func (h httpFetcher) Get(url string) (*http.Response, error) {
-	return http.Get(url)
+	client := http.Client{ Timeout: time.Second * 2 }
+	return client.Get(url)
 }
 
 func (a *alert) Fetch() (float64, error) {
@@ -118,6 +119,10 @@ func (a *alert) Fetch() (float64, error) {
 		a.Status = "Error"
 		a.Message = err.Error()
 	}
+
+	// Close the response
+	resp.Body.Close()
+
 	return lv, err
 }
 


### PR DESCRIPTION
Hound sometimes gives errors like these when it's backed up:

    http: Accept error: accept tcp [::]:9999: accept4: too many open files;

I think this can be avoided with the changes here. It's best practice to
close the http.Get() response, and also to use a new instance of
http.Client instead of the http.DefaultClient singleton (used by calls
to http.Get()).

I've given the new http.Client a 2-second timeout, which should be fine,
but we can adjust as needed.

* https://stackoverflow.com/a/48342086/173630
* https://golang.org/pkg/net/http/