### PR TITLE
Increase graphite graph resolution on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,8 +41,8 @@ a.Error { background-color: #f60;}
                 {{ end }}
                 <div class="clearfix"></div>
             </div>
-            <img width="800" height="150" src="{{.GraphiteBase}}?width=800&height=150&_salt=1399312175.381&target=keepLastValue({{.MetricBase}}errors)&target=keepLastValue({{.MetricBase}}successes)&target=keepLastValue({{.MetricBase}}failures)&from=-24hours&areaMode=stacked&bgcolor=ffffff&fgcolor=333333&colorList=ff6600,44bb44,ff0000"/><br />
-            <img width="800" height="75" src="{{.GraphiteBase}}?width=800&height=75&hideGrid=true&hideLegend=true&graphOnly=false&hideAxes=false&_salt=1399312175.381&target=keepLastValue({{.MetricBase}}errors)&target=keepLastValue({{.MetricBase}}successes)&target=keepLastValue({{.MetricBase}}failures)&from=-7days&areaMode=stacked&bgcolor=eeeeee&fgcolor=333333&colorList=ff6600,44bb44,ff0000"/>
+            <img width="800" height="150" src="{{.GraphiteBase}}?width=1600&height=300&fontSize=20&_salt=1399312175.381&target=keepLastValue({{.MetricBase}}errors)&target=keepLastValue({{.MetricBase}}successes)&target=keepLastValue({{.MetricBase}}failures)&from=-24hours&areaMode=stacked&bgcolor=ffffff&fgcolor=333333&colorList=ff6600,44bb44,ff0000"/><br />
+            <img width="800" height="75" src="{{.GraphiteBase}}?width=1600&height=150&fontSize=20&hideGrid=true&hideLegend=true&graphOnly=false&hideAxes=false&_salt=1399312175.381&target=keepLastValue({{.MetricBase}}errors)&target=keepLastValue({{.MetricBase}}successes)&target=keepLastValue({{.MetricBase}}failures)&from=-7days&areaMode=stacked&bgcolor=eeeeee&fgcolor=333333&colorList=ff6600,44bb44,ff0000"/>
         </div>
 
 <table class="table table-sm table-striped table-responsive">


### PR DESCRIPTION
This makes it easier to read.

<img width="980" alt="Screen Shot 2020-05-18 at 1 07 30 PM" src="https://user-images.githubusercontent.com/59292/82240591-aa0d2e00-9908-11ea-9fe0-a880bbff6d7d.png">
